### PR TITLE
Avoid duplicating the MATLAB filter cache

### DIFF
--- a/rust_bridge/README.md
+++ b/rust_bridge/README.md
@@ -21,7 +21,6 @@ four overnight recordings (see [Backend parity](#backend-parity) below).
 | `refine_peaks_mex.c` | Hann-FFT refinement of peak frequencies |
 | `tfpeak_histogram_mex.c` | SO-power / SO-phase histogram accumulation |
 | `extract_tfpeaks_mex.mex*` etc. | Platform-specific compiled binaries (checked in) |
-| `data_matlab_filters/` | Runtime filter cache copied from `DYNAM-O_rs` by the builder |
 
 ---
 
@@ -113,10 +112,12 @@ current platform:
 | Linux | `.mexa64` | `extract_tfpeaks_mex.mexa64`, … |
 | Windows | `.mexw64` | `extract_tfpeaks_mex.mexw64`, … |
 
-The shared library is copied beside the MEX files, together with the
-runtime `data_matlab_filters` directory. macOS and Linux use loader-relative
-references (`@loader_path`/`@rpath` and `$ORIGIN`, respectively), while
-Windows loads the adjacent DLL.
+The shared library is copied beside the MEX files. The MEX interface receives
+filter coefficients from MATLAB, so it does not need the Python runtime's
+`data_matlab_filters` cache and the builder does not duplicate that directory
+under `rust_bridge`. macOS and Linux use loader-relative references
+(`@loader_path`/`@rpath` and `$ORIGIN`, respectively), while Windows loads the
+adjacent DLL.
 
 ### Sanity check
 

--- a/rust_bridge/build_rust_mex.m
+++ b/rust_bridge/build_rust_mex.m
@@ -137,7 +137,6 @@ if ~copied
     error('build_rust_mex:LibraryCopyFailed', ...
         'Failed to copy %s: %s', dylib_name, copy_message);
 end
-copy_filter_cache(rs_root, here);
 if ispc
     % Windows also needs the import library (.dll.lib) at link time
     % but NOT at runtime; skip copying the .lib here.
@@ -299,38 +298,6 @@ for i = 1:numel(candidates)
              'DYNAM-O_rs crate: %s -> %s'], candidate, resolved);
     end
 end
-end
-
-function copy_filter_cache(rs_root, here)
-source_dir = fullfile(fileparts(rs_root), 'data_matlab_filters');
-assert(isfolder(source_dir), ...
-    'MATLAB filter cache not found at %s.', source_dir);
-source_files = dir(fullfile(source_dir, '*.npy'));
-assert(numel(source_files) == 42, ...
-    'Expected 42 MATLAB filter-cache .npy files at %s; found %d.', ...
-    source_dir, numel(source_files));
-[~, order] = sort({source_files.name});
-source_files = source_files(order);
-
-destination_dir = fullfile(here, 'data_matlab_filters');
-if ~isfolder(destination_dir)
-    mkdir(destination_dir);
-end
-old_files = dir(fullfile(destination_dir, '*.npy'));
-for i = 1:numel(old_files)
-    delete(fullfile(destination_dir, old_files(i).name));
-end
-for i = 1:numel(source_files)
-    [copied, message] = copyfile( ...
-        fullfile(source_dir, source_files(i).name), ...
-        fullfile(destination_dir, source_files(i).name));
-    if ~copied
-        error('build_rust_mex:FilterCacheCopyFailed', ...
-            'Failed to copy %s: %s', source_files(i).name, message);
-    end
-end
-fprintf('Copied %d filter-cache files -> rust_bridge/data_matlab_filters.\n', ...
-    numel(source_files));
 end
 
 function encoded = release_rustflags(rs_root, workspace_root)


### PR DESCRIPTION
## Summary

- Stop `build_rust_mex` from copying the canonical 42-file filter cache into `rust_bridge`.
- Document that the MEX interface receives filter coefficients from MATLAB and does not use the Python runtime cache.
- Leave the shared-library copy and loader-relative linking behavior unchanged.

## Root cause

Commit `0cfcb098` added a `data_matlab_filters` sidecar copy while hardening native release builds against build-host paths. The MEX C API already receives SOS coefficients from MATLAB, so the copied cache is not used by the MATLAB bridge.

## Impact

Running the coordinated bootstrap/build no longer creates a redundant `DYNAM-O/rust_bridge/data_matlab_filters` directory. Python packaging remains unchanged and continues to include its own runtime cache.

Companion release-orchestrator change: https://github.com/preraulab/DYNAM-O_toolbox/pull/8

## Validation

- Built all ten MEX wrappers with MATLAB R2025b after removing the copy step.
- Confirmed the build did not recreate `rust_bridge/data_matlab_filters`.
- Ran `validate_so_phase_mex`; all smoke gates passed.