### PR TITLE
Avoid rebuilding Rust during controlled MEX builds

### DIFF
--- a/rust_bridge/README.md
+++ b/rust_bridge/README.md
@@ -73,6 +73,12 @@ cd <workspace>/DYNAM-O/rust_bridge
 build_rust_mex
 ```
 
+The parent release builder instead calls `build_rust_mex('prebuilt')` after one
+controlled Cargo invocation has produced the Rust CLI, `rlib`, and shared
+library. This avoids recompiling the same Rust dependency graph before the MEX
+wrappers are linked. The `prebuilt` mode is reserved for the parent builder;
+direct calls should use the no-argument form so the shared library is rebuilt.
+
 Do not commit artifacts produced by the direct helper: although it remaps Rust
 and C compiler source paths, it does not run the meta-repository's final
 artifact privacy checks or write the release provenance manifest.

--- a/rust_bridge/build_rust_mex.m
+++ b/rust_bridge/build_rust_mex.m
@@ -1,9 +1,15 @@
-function build_rust_mex()
+function build_rust_mex(mode)
 %BUILD_RUST_MEX  Compile the MEX wrappers that bridge MATLAB to dynamo_rs.
 %
 %   Usage:
 %       cd /path/to/DYNAM-O/rust_bridge
 %       build_rust_mex
+%       build_rust_mex('prebuilt')
+%
+%   With no argument, the helper builds the Rust library before compiling
+%   the MEX wrappers. The parent DYNAM-O_toolbox release builder passes
+%   'prebuilt' after producing the CLI, Rust library, and shared library in
+%   one controlled Cargo invocation.
 %
 %   Prerequisites (must all be true before calling):
 %     1. DYNAM-O_rs exists as a sibling checkout:
@@ -31,6 +37,13 @@ function build_rust_mex()
 %   The MEX binaries link against a copy of libdynamo_rs placed beside
 %   them, using loader-relative lookup so the output is redistributable.
 
+if nargin == 0
+    mode = 'build';
+elseif nargin ~= 1 || ~ischar(mode) || ~strcmp(mode, 'prebuilt')
+    error('build_rust_mex:InvalidMode', ...
+        'Usage: build_rust_mex or build_rust_mex(''prebuilt'').');
+end
+
 here           = canonical_path(fileparts(mfilename('fullpath'))); % DYNAM-O/rust_bridge
 dev_root       = fileparts(here);                                % DYNAM-O
 workspace_root = fileparts(dev_root);                            % parent of all three repos
@@ -47,7 +60,11 @@ else
     dylib_name = 'libdynamo_rs.so';
 end
 mex_remap_args = compiler_path_remap_args(workspace_root);
-build_rust_library(rs_root, workspace_root, dylib_name);
+if strcmp(mode, 'build')
+    build_rust_library(rs_root, workspace_root, dylib_name);
+else
+    fprintf('Using the Rust library prebuilt by DYNAM-O_toolbox ...\n');
+end
 
 inc_dir   = fullfile(rs_root, 'include');
 lib_dir   = fullfile(rs_root, 'target', 'release');

--- a/tests/test_build_rust_mex_mode.m
+++ b/tests/test_build_rust_mex_mode.m
@@ -1,0 +1,25 @@
+function tests = test_build_rust_mex_mode
+%TEST_BUILD_RUST_MEX_MODE  Validate the explicit parent-build mode.
+tests = functiontests(localfunctions);
+end
+
+function setupOnce(testCase)
+this_dir = fileparts(mfilename('fullpath'));
+repo_root = fileparts(this_dir);
+import matlab.unittest.fixtures.PathFixture
+testCase.applyFixture(PathFixture(fullfile(repo_root, 'rust_bridge')));
+end
+
+function teardownOnce(~)
+clear build_rust_mex
+end
+
+function test_rejects_unknown_mode(testCase)
+testCase.verifyError(@() build_rust_mex('unknown'), ...
+    'build_rust_mex:InvalidMode');
+end
+
+function test_rejects_non_character_mode(testCase)
+testCase.verifyError(@() build_rust_mex(false), ...
+    'build_rust_mex:InvalidMode');
+end


### PR DESCRIPTION
## Summary

- add an explicit `build_rust_mex('prebuilt')` mode for the parent release builder
- keep the no-argument `build_rust_mex` workflow self-contained: it still performs its own locked, path-remapped Rust build
- document the two invocation contracts and reject unsupported modes with a focused MATLAB test

## Why

`DYNAM-O_toolbox` already builds the native Rust crate before launching MATLAB. The MATLAB helper then rebuilt the same non-Python Rust dependency graph solely to obtain the shared library. The explicit mode lets the controlled parent build reuse a freshly produced library while preserving the standalone developer workflow.

## Validation

- MATLAB mode tests: 2 passed
- direct `build_rust_mex` invocation on the rebased branch: Cargo ran and all ten MEX wrappers built successfully
- `build_rust_mex('prebuilt')`: all ten wrappers built without a Cargo phase
- `extract_tfpeaks_mex` smoke call passed against the combined prebuilt shared library
- coordinated privacy scan from `DYNAM-O_toolbox`: 0 findings across 60 release artifacts and 2 internal Rust artifacts

## Coordination

Companion: [preraulab/DYNAM-O_toolbox#9](https://github.com/preraulab/DYNAM-O_toolbox/pull/9). Merge this PR first; the toolbox PR then begins calling the new `prebuilt` mode.